### PR TITLE
Add autoload declaration

### DIFF
--- a/keyfreq.el
+++ b/keyfreq.el
@@ -69,7 +69,7 @@ a statistical data."
   :group 'local
   :prefix "keyfreq")
 
-
+;;;###autoload
 (define-minor-mode keyfreq-mode
   "Keyfreq mode records number of times each command was
 called making it possible to access usage statistics through
@@ -443,7 +443,7 @@ The table is not reset, so the values are appended to the table."
 	  (setq l (cdr l)))
 	)))
 
-
+;;;###autoload
 (define-minor-mode keyfreq-autosave-mode
   "Keyfreq Autosave mode automatically saves
 `keyfreq-table' every `keyfreq-autosave-timeout' seconds


### PR DESCRIPTION
This just makes it a bit more convenient to use together with package.el that's now part of emacs. Users don't have to `require` the package, it will load automatically when the mode is activated.
