### PR TITLE
Fixed saving to file

### DIFF
--- a/keyfreq.el
+++ b/keyfreq.el
@@ -427,7 +427,9 @@ if it was successfully merged."
 
 	      ;; Write the new frequencies
 	      (with-temp-file keyfreq-file
-		(prin1 (cdr (keyfreq-list table 'no-sort)) (current-buffer))))
+		(let ((print-level nil)
+		      (print-length nil))
+		  (prin1 (cdr (keyfreq-list table 'no-sort)) (current-buffer)))))
 
 	  ;; Release the lock and reset the hash table.
 	  (keyfreq-file-release-lock)


### PR DESCRIPTION
Clearly we want to save all the data to the file, so we have to ensure that `print-level' and`print-length' are nil.
