### PR TITLE
fix #18. Conflict name with `reduce` from `cl-lib` or `cl`

### DIFF
--- a/keyfreq.el
+++ b/keyfreq.el
@@ -73,9 +73,12 @@
 ;;
 ;;; Code:
 
-(if (featurep 'cl-lib)
-    (require 'cl-lib)
-  (require 'cl))
+(if (not (featurep 'cl-lib))
+    (progn
+      (require 'cl)
+      ;; fix conflict name
+      (defalias 'cl-reduce 'reduce))
+  (require 'cl-lib))
 ;; (require 'json)?
 
 (defgroup keyfreq nil
@@ -219,7 +222,7 @@ for each entry with three arguments: number of times command was
 called, percentage usage and the command."
   (let* ((sum (car list))
          (max-len
-          (reduce (lambda (a b) (max a (length (symbol-name (car b)))))
+          (cl-reduce (lambda (a b) (max a (length (symbol-name (car b)))))
                   (cdr list)
                   :initial-value 0)))
     (mapconcat


### PR DESCRIPTION
This leads to Symbol error. See bug #16 and #9

Since `cl-lib` seems included in Emacs 24,
and since there is debates about names from `cl` library,
it appears judicious to use by default `cl-reduce` instead of just `reduce`.