### PR TITLE
add Package-Requires: cl-lib

### DIFF
--- a/keyfreq.el
+++ b/keyfreq.el
@@ -10,6 +10,9 @@
 ;; Maintainer: David Capello, Xah lee
 ;; Created: 2006
 ;;
+;; Package-Requires: ((cl-lib "0.5"))
+;;
+;;
 ;; Keyfreq is free software; you can redistribute it and/or modify it
 ;; under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation; either version 3 of the License, or


### PR DESCRIPTION
Following the discussion about the dependencies management by `package.el` and MELPA (see [#3855](https://github.com/melpa/melpa/issues/3855)) this patch should fix the issue of the dependency to the function `cl-reduce`.

 - `cl-lib` is included in Emacs 24.3+, therefore there is no dependency issue anymore about `(require 'cl-lib)`.
 - the added line insures that `package.el` will manage `cl-lib`, possibly downloading it even for Emacs 24.3+. However, it is small and stable, upgrading barely.
