### PR TITLE
Fixed: ill-formed let binding in keyfreq-table

### DIFF
--- a/keyfreq.el
+++ b/keyfreq.el
@@ -436,7 +436,7 @@ is used as MAJOR-MODE-SYMBOL argument."
 
 (defun keyfreq-file-owner ()
   "Return the PID of the Emacs process that owns the table file lock file."
-  (let (owner)
+  (let ((owner))
     (and (file-exists-p keyfreq-file-lock)
 	 (ignore-errors
 	   (with-temp-buffer

--- a/keyfreq.el
+++ b/keyfreq.el
@@ -480,7 +480,7 @@ does nothing if the table cannot be saved."
 
   ;; Avoid adding nothing to the file
   (if (> (hash-table-count table) 0)
-    (let (done)
+    (let ((done))
       ;; Check that the lock file doesn't exist
       (while (not done)
 	(when (keyfreq-file-is-unlocked)


### PR DESCRIPTION
Was made in response to the following error
```lisp
Debugger entered--Lisp error: (error "`let' bindings can have only one value-form" while (and (listp l) l) (if (listp (car l)) (if (keyfreq-match-p (cdr (car (car l)))) nil (puthash (car (car l)) (+ (gethash (car (car l)) table 0) (cdr (car l))) table))) (setq l (cdr l)))
  (let ((l (let ((temp-buffer (generate-new-buffer " *temp*" t))) (save-current-buffer (set-buffer temp-buffer) (unwind-protect (progn (insert-file-contents keyfreq-file) (goto-char ...) (condition-case error ... ...)) (and (buffer-name temp-buffer) (kill-buffer temp-buffer)))))) (while (and (listp l) l) (if (listp (car l)) (if (keyfreq-match-p (cdr (car ...))) nil (puthash (car (car l)) (+ (gethash ... table 0) (cdr ...)) table))) (setq l (cdr l)))) nil)
  (if (file-exists-p keyfreq-file) (let ((l (let ((temp-buffer (generate-new-buffer " *temp*" t))) (save-current-buffer (set-buffer temp-buffer) (unwind-protect (progn ... ... ...) (and ... ...))))) (while (and (listp l) l) (if (listp (car l)) (if (keyfreq-match-p (cdr ...)) nil (puthash (car ...) (+ ... ...) table))) (setq l (cdr l)))) nil))
  keyfreq-table-load(#<hash-table equal 11/128 0x1561a8f1664d>)
  (progn (keyfreq-table-load table) (let ((temp-file keyfreq-file) (temp-buffer (generate-new-buffer " *temp file*" t))) (unwind-protect (prog1 (save-current-buffer (set-buffer temp-buffer) (let ((l ...)) (insert "(") (let (... item) (while --dolist-tail-- ... ... ... ...)) (insert ")"))) (save-current-buffer (set-buffer temp-buffer) (write-region nil nil temp-file nil 0))) (and (buffer-name temp-buffer) (kill-buffer temp-buffer)))))
  (unwind-protect (progn (keyfreq-table-load table) (let ((temp-file keyfreq-file) (temp-buffer (generate-new-buffer " *temp file*" t))) (unwind-protect (prog1 (save-current-buffer (set-buffer temp-buffer) (let (...) (insert "(") (let ... ...) (insert ")"))) (save-current-buffer (set-buffer temp-buffer) (write-region nil nil temp-file nil 0))) (and (buffer-name temp-buffer) (kill-buffer temp-buffer))))) (clrhash table) (setq done t) (keyfreq-file-release-lock))
  (if (eq (keyfreq-file-owner) (emacs-pid)) (unwind-protect (progn (keyfreq-table-load table) (let ((temp-file keyfreq-file) (temp-buffer (generate-new-buffer " *temp file*" t))) (unwind-protect (prog1 (save-current-buffer (set-buffer temp-buffer) (let ... ... ... ...)) (save-current-buffer (set-buffer temp-buffer) (write-region nil nil temp-file nil 0))) (and (buffer-name temp-buffer) (kill-buffer temp-buffer))))) (clrhash table) (setq done t) (keyfreq-file-release-lock)))
  (progn (keyfreq-file-claim-lock) (if (eq (keyfreq-file-owner) (emacs-pid)) (unwind-protect (progn (keyfreq-table-load table) (let ((temp-file keyfreq-file) (temp-buffer (generate-new-buffer " *temp file*" t))) (unwind-protect (prog1 (save-current-buffer ... ...) (save-current-buffer ... ...)) (and (buffer-name temp-buffer) (kill-buffer temp-buffer))))) (clrhash table) (setq done t) (keyfreq-file-release-lock))))
  (if (keyfreq-file-is-unlocked) (progn (keyfreq-file-claim-lock) (if (eq (keyfreq-file-owner) (emacs-pid)) (unwind-protect (progn (keyfreq-table-load table) (let ((temp-file keyfreq-file) (temp-buffer ...)) (unwind-protect (prog1 ... ...) (and ... ...)))) (clrhash table) (setq done t) (keyfreq-file-release-lock)))))
  (while (not done) (if (keyfreq-file-is-unlocked) (progn (keyfreq-file-claim-lock) (if (eq (keyfreq-file-owner) (emacs-pid)) (unwind-protect (progn (keyfreq-table-load table) (let (... ...) (unwind-protect ... ...))) (clrhash table) (setq done t) (keyfreq-file-release-lock))))) (if (and (not done) mustsave) (sleep-for 0.1) (setq done t)))
  (let ((done)) (while (not done) (if (keyfreq-file-is-unlocked) (progn (keyfreq-file-claim-lock) (if (eq (keyfreq-file-owner) (emacs-pid)) (unwind-protect (progn (keyfreq-table-load table) (let ... ...)) (clrhash table) (setq done t) (keyfreq-file-release-lock))))) (if (and (not done) mustsave) (sleep-for 0.1) (setq done t))))
  (if (> (hash-table-count table) 0) (let ((done)) (while (not done) (if (keyfreq-file-is-unlocked) (progn (keyfreq-file-claim-lock) (if (eq (keyfreq-file-owner) (emacs-pid)) (unwind-protect (progn ... ...) (clrhash table) (setq done t) (keyfreq-file-release-lock))))) (if (and (not done) mustsave) (sleep-for 0.1) (setq done t)))))
  keyfreq-table-save(#<hash-table equal 11/128 0x1561a8f1664d>)
  keyfreq-autosave--do()
  eval-expression((keyfreq-autosave--do) nil nil 127)
  funcall-interactively(eval-expression (keyfreq-autosave--do) nil nil 127)
  command-execute(eval-expression)
```

This appears to only happen when autosave is enabled